### PR TITLE
Fix key terms body details from loading properly.

### DIFF
--- a/keyterms/keyterms.py
+++ b/keyterms/keyterms.py
@@ -158,7 +158,7 @@ class KeytermsXBlock(XBlock):
             cardItem += '      </h5>\n'
             cardItem += '   </div>\n'
             cardItem += '   <div id="{keyterm_data_target}" class="collapse {keyterm_show}" aria-labelledby="{keyterm_card_header_id}" data-parent="{div_parent_id}">\n'
-            cardItem += '      <div class="card-body">\n'
+            cardItem += '      <div class="{keyterm_data_target} card-body">\n'
             cardItem += '         Example Content.\n'
             cardItem += '      </div>\n'
             cardItem += '   </div>\n'


### PR DESCRIPTION
The term body details was not loading because we needed to add in the #keyterm_data_target in the CSS selector.