### PR TITLE
fix: Left aligned key term title and made definition title relative to number of terms available.

### DIFF
--- a/keyterms/static/css/collapse.css
+++ b/keyterms/static/css/collapse.css
@@ -195,7 +195,7 @@ tbody.collapse.in {
 .collapse-btn {
     display: block;
     font-weight: 400;
-    text-align: center;
+    text-align: left;
     white-space: nowrap;
     -webkit-user-select: none;
     -moz-user-select: none;

--- a/keyterms/static/js/src/keyterms.js
+++ b/keyterms/static/js/src/keyterms.js
@@ -252,7 +252,14 @@ function KeytermsXBlock(runtime, element, initData) {
 
                 // Definitions
                 if (keytermInformation["definitions"].length > 0) {
-                    formattedContent += `<div class="flex-col"><b>Definitions</b><ul class="bullets">`;
+                    formattedContent += `<div class="flex-col">`
+                    if (keytermInformation["definitions"].length > 1) {
+                        formattedContent += `<b>Definitions</b>`
+                    }
+                    else {
+                        formattedContent += `<b>Definition</b>`
+                    }
+                    formattedContent += `<ul class="bullets">`;
                     keytermInformation["definitions"].forEach(definition => {
                         formattedContent += `<li>${definition["description"]}</li>`
                     })


### PR DESCRIPTION
Ref: https://educateworkforce.zendesk.com/agent/tickets/830

Updated the highlighted text.

![image](https://github.com/CUCWD/xblock-keyterms/assets/5641338/17bee3fb-e164-4059-aca6-6ca1d2be92f8)
